### PR TITLE
Removes task schema from example config, adds to default config

### DIFF
--- a/examples/config.example.json
+++ b/examples/config.example.json
@@ -1,7 +1,5 @@
 {
     "work_dir": "/path/to/scriptworker/tmp/work",
-    "mark_as_shipped_schema_file": "/path/to//shipitscript/data/mark_as_shipped_task_schema.json",
-    "mark_as_started_schema_file": "/path/to//shipitscript/data/mark_as_started_task_schema.json",
 
     "ship_it_instances": {
         "project:releng:ship-it:server:dev": {

--- a/shipitscript/script.py
+++ b/shipitscript/script.py
@@ -80,10 +80,13 @@ ACTION_MAP = {
 def get_default_config():
     cwd = os.getcwd()
     parent_dir = os.path.dirname(cwd)
+    data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
     return {
         'work_dir': os.path.join(parent_dir, 'work_dir'),
         'verbose': False,
+        'mark_as_shipped_schema_file': os.path.join(data_dir, 'mark_as_shipped_task_schema.json'),
+        'mark_as_started_schema_file': os.path.join(data_dir, 'mark_as_started_task_schema.json'),
     }
 
 

--- a/shipitscript/test/test_script.py
+++ b/shipitscript/test/test_script.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import shipitscript
 from unittest.mock import MagicMock
 
 from scriptworker import client
@@ -189,9 +190,12 @@ async def test_async_main(context, monkeypatch, task, raises):
 
 def test_get_default_config():
     parent_dir = os.path.dirname(os.getcwd())
+    data_dir = os.path.join(os.path.dirname(shipitscript.__file__), 'data')
     assert script.get_default_config() == {
         'work_dir': os.path.join(parent_dir, 'work_dir'),
         'verbose': False,
+        'mark_as_shipped_schema_file': os.path.join(data_dir, 'mark_as_shipped_task_schema.json'),
+        'mark_as_started_schema_file': os.path.join(data_dir, 'mark_as_started_task_schema.json'),
     }
 
 


### PR DESCRIPTION
See [the related `scriptworker` bug](https://github.com/mozilla-releng/scriptworker/issues/287)